### PR TITLE
Move python assignments into pre-work repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ We'll have an intro call during this first week where we will outline what’s e
 
 #### Week 3 - Programming in Python
 - [Scrimba interactive Python tutorial](https://scrimba.com/learn/python/course-introduction-c9Bv3wc8)
-- [Code Platoon written tutorial - intro](/python_fundamentals.md) 
-- [Code Platoon written tutorial - intermediate](/python_intermediate.md) 
+- [Code Platoon written tutorial - intro](/python_fundamentals.md)
+- [Code Platoon written tutorial - intermediate](/python_intermediate.md)
 - [Object Oriented Programming in Python](https://youtu.be/JeznW_7DlB0)
 - **[Mandatory CoderByte Assessment](https://coderbyte.com/sl-candidate?promo=codeplatoon-13p1p:technical-asses-x9bqbaveyk)**
 - Complete AWS Cloud Practioner Essentials Module 6 - Security

--- a/algo-anagrams-i/README.md
+++ b/algo-anagrams-i/README.md
@@ -1,0 +1,16 @@
+# Character Match Challenge
+
+For this challenge you will make a program that takes in two different strings and see if the invidual letter or number characters in a string match in both strings. For example, 'abcde2' can be rearranged to 'c2abed'.
+
+## Example
+Your program should return true for all the following examples...
+```
+is_anagram('charm', 'march')
+is_anagram('CharM', 'mARcH')
+is_anagram('abcde2', 'c2abed')
+```
+## Remember
+Run your test specs early and often. Also, if you come across a scenario that isn't included in your test suite, then you should absolutely add it!
+
+## Challenge Yourself
+* Solve this same exercise without using Python's built-in `sorted` method.

--- a/algo-anagrams-i/python/character_match.py
+++ b/algo-anagrams-i/python/character_match.py
@@ -1,0 +1,5 @@
+# Don't forget to run your tests!
+
+def is_character_match(string1, string2):
+	pass
+	# Your code here

--- a/algo-anagrams-i/python/character_match_spec.py
+++ b/algo-anagrams-i/python/character_match_spec.py
@@ -1,0 +1,13 @@
+from character_match import is_character_match
+
+# This should return a bunch of trues
+print(is_character_match('charm', 'march') == True)
+print(is_character_match('zach', 'attack') == False)
+print(is_character_match('CharM', 'mARcH') == True)
+print(is_character_match('abcde2', 'c2abed') == True)
+
+print("This test is for the challenge quesiton")
+print(is_character_match('Anna Madrigal', 'A man and a girl') == True)
+
+
+# Can you translate this driver code to unit tests?

--- a/algo-armstrong-numbers/README.md
+++ b/algo-armstrong-numbers/README.md
@@ -1,0 +1,27 @@
+# Armstrong Numbers
+
+An Armstrong Number is an N-digit number that is equal to the sum of the Nth powers of its digits.
+
+An example is all single digit numbers. Take `5` for example. `5` is a single digit and `5^1` is equal to `5`, therefore it is an Armstrong number.
+```python
+5 = 5^1
+5 = 5
+```
+Another example is `371`. `371` is three digits. `3^3 + 7^3 + 1^3` is `27 + 343 + 1`, which added together is `371`. Thus `371` is an Armstrong number.
+
+```javascript
+371 = 3^3 + 7^3 + 1^3
+371 = 27 + 343 + 1
+371 = 371
+```
+
+## Release 0
+Write a program in Python and Javascript to find all Armstrong numbers in the range of `0` and `999`. __The function should take in a list/array of numbers from 0-999 and return a list of Armstrong numbers.__
+
+Don't forget to run the tests!
+
+## Release 1: Refactor
+Review your code, How can you make this more scalable and reusable later?
+
+### Stretch Yourself
+- Can you think of any more tests for your program?

--- a/algo-armstrong-numbers/python/armstrong_numbers.py
+++ b/algo-armstrong-numbers/python/armstrong_numbers.py
@@ -1,0 +1,2 @@
+# How can you make this more scalable and reusable later?
+def find_armstrong_numbers(numbers):

--- a/algo-armstrong-numbers/python/armstrong_numbers_spec.py
+++ b/algo-armstrong-numbers/python/armstrong_numbers_spec.py
@@ -1,0 +1,7 @@
+# The code is written as driver code. Can you convert it to Unit Test?
+from armstrong_numbers import find_armstrong_numbers
+
+print(find_armstrong_numbers([0]) == [0]) 
+print(find_armstrong_numbers(list(range(0, 8))) == [0, 1, 2, 3, 4, 5, 6, 7])
+print(find_armstrong_numbers(list(range(0,100))) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+print(find_armstrong_numbers(list(range(0,999))) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 153, 370, 371, 407])

--- a/algo-credit-check/README.md
+++ b/algo-credit-check/README.md
@@ -1,0 +1,37 @@
+# Credit Check
+
+## Premise
+
+The Luhn algorithm is a check-summing algorithm best known for checking the validity of credit card numbers.
+
+You can checkout the full description on Wikipedia: http://en.wikipedia.org/wiki/Luhn_algorithm
+
+### Description
+
+(adapted from Wikipedia)
+
+The formula verifies a number against its included check digit, which is usually appended to a partial account number to generate the full account number. This full account number must pass the following test:
+
+* from the rightmost digit, which is the check digit, moving left, double the value of every other digit
+* if product of this doubling operation is greater than 9 (e.g., 7 * 2 = 14), then sum the digits of the products (e.g., 10: 1 + 0 = 1, 14: 1 + 4 = 5).
+* take the sum of all the digits
+* if and only if the total modulo 10 is equal to 0 then the number is valid
+
+### Example
+
+#### Validating an Account Number
+
+We can use the same process to validate an account number. Using `5541808923795240` as our sample input:
+
+```
+Account identifier:    5   5   4   1   8   0   8   9   2   3   7   9   5   2   4   0
+2x every other digit:  10  5   8   1   16  0   16  9   4   3   14  9   10  2   8   0
+Summed digits over 10: 1   5   8   1   7   0   7   9   4   3   5   9   1   2   8   0
+Results summed:        1   5   8   1   7   0   7   9   4   3   5   9   1   2   8   0 = 70
+```
+
+Since the summed results modulo 10 is zero, the account number is valid according to the algorithm.
+
+## Exercise
+
+Your objective, using the knowledge above, is to write a program that implements the Luhn algorithm to validate a credit card number

--- a/algo-credit-check/python/credit_check.py
+++ b/algo-credit-check/python/credit_check.py
@@ -1,0 +1,8 @@
+def credit_check(str):
+    pass
+
+# Your Luhn Algorithm Here
+# Expected Output:
+# If it is valid, print "The number is valid!"
+# If it is invalid, print "The number is invalid!"
+

--- a/algo-credit-check/python/credit_check_spec.py
+++ b/algo-credit-check/python/credit_check_spec.py
@@ -1,0 +1,11 @@
+# Can you translate this driver code to unit tests?
+
+from credit_check import credit_check
+
+print(credit_check('5541808923795240') == "The number is valid!")
+print(credit_check("4024007136512380") == "The number is valid!")
+print(credit_check("6011797668867828") == "The number is valid!")
+
+print(credit_check("5541801923795240") == "The number is invalid!")
+print(credit_check("4024007106512380") == "The number is invalid!")
+print(credit_check("6011797668868728") == "The number is invalid!")

--- a/algo-debugging-one/README.md
+++ b/algo-debugging-one/README.md
@@ -1,0 +1,13 @@
+# First Missing Positive Integer
+You are given an array of integers. Return the smallest positive integer that is not present in the array. The array may contain duplicate entries.
+
+For example, the input [3, 4, -1, 1] should return 2 because it is the smallest positive integer that doesn't exist in the array.
+
+Someone tried to write a solution but didn't know python very well and wasn't sure if they got the correct solution.
+
+Please debug to get the correct output.
+
+```py
+print first_missing_positive([3, 4, -1, 1])
+# 2
+```

--- a/algo-debugging-one/first_missing_positive_integer.py
+++ b/algo-debugging-one/first_missing_positive_integer.py
@@ -1,0 +1,27 @@
+def first_missing_positive(nums)
+    # if empty list, return 1
+    if not nums:
+        return 1
+    
+    # run through list to move valid values "v" to be located at index "v - 1"
+    for i, num in enumerate(nums):
+    # relocate the value "v" (0 < v < length) from the current index to index "v - 1"
+    # values outside of "0 < v < length" don't matter
+    while i + 1 != nums[i] and 0 < nums[i] <= len(nums):
+        # obtain the current value
+        v = nums[i]+1:
+            # swap values in the list so that index "v - 1" now holds current value "v"
+            # the current index location will now hold the value that was swapped against
+            nums[i], nums[v - 1] = nums[v - 1], nums[i]
+        
+        # break out of while loop if current value and swapped value are the same
+        if nums[i] == nums[v + 1]:
+        break
+
+    # search through the list until we find an index where the value doesn't not equal "index + 1" (which is the location of where the missing number should be!)
+    for i, num in enumerate(nums, 1):
+        if num != i:
+        return i
+
+    # if we get through out entire list, that means all positive numbers are includes from 1-length, so the next missing positive number is the length+1
+    return len(nums) + 1

--- a/algo-sum-pairs/README.md
+++ b/algo-sum-pairs/README.md
@@ -1,0 +1,10 @@
+# Sum Pairs
+
+Write a method that takes an integer array and a desired sum. The output will be pairs of numbers from the inputed integer array that equal that desired sum. If there are no pairs that work, return 'unable to find pairs'
+
+Sample output:
+```
+sum_pairs([1,2,3,4,5], 9) # [[4,5]]
+sum_pairs([1,2,3,4,5], 7) # [[2,5], [3,4]]
+sum_pairs([3, 1, 5, 8, 2], 27) # 'unable to find pairs'
+```

--- a/algo-sum-pairs/python/sum_pairs.py
+++ b/algo-sum-pairs/python/sum_pairs.py
@@ -1,0 +1,1 @@
+def sum_pairs():

--- a/algo-sum-pairs/python/sum_pairs_spec.py
+++ b/algo-sum-pairs/python/sum_pairs_spec.py
@@ -1,0 +1,3 @@
+from sum_pairs import sum_pairs
+
+# write your specs here!

--- a/python_intermediate.md
+++ b/python_intermediate.md
@@ -127,13 +127,14 @@ anything.say_hello()
 ```
 We just created two files: `file1.py` and `file2.py`. `file1.py` has a `say_hello` function. `file2.py` has nothing in it, but imports that file in as the name of the file and we can use all the methods in that file. We can also rewrite it as `import file1 as anything` and call `anything.say_hello()`. You can `import` anything into your file by providing the correct relative path to the file. More on that can be found under external resources.
 
-## Resources
+## Required Reading
+
 - [Python Modules](https://www.tutorialspoint.com/python/python_modules.htm)
 
 ## Assignments
 
-- [Armstrong Numbers](https://github.com/codeplatoon-devops/algo-armstrong-numbers)
-- [Sum Pairs](https://github.com/codeplatoon-devops/algo-sum-pairs)
-- [Credit Check](https://github.com/codeplatoon-devops/algo-credit-check)
-- [Anagrams I](https://github.com/codeplatoon-devops/algo-anagrams-i)
-- [Debugging One](https://github.com/codeplatoon-devops/algo-debugging-one)
+- [Armstrong Numbers](/algo-armstrong-numbers)
+- [Sum Pairs](/algo-sum-pairs)
+- [Credit Check](/algo-credit-check)
+- [Anagrams I](/algo-anagrams-i)
+- [Debugging One](/algo-debugging-one)


### PR DESCRIPTION
Pre-work Students were unable to access python assignment repos because they were private & pre-work students haven't been added to our github org yet.

Previously the intermediate python assignments were all in separate repos. As this pre-work repo is currently public, for easier distribution to students, and the assignment repos were private, simply putting all the assignments in the pre-work repo makes more sense.

Later when our overall github organization is more settled & we can be confident assignments will always live in the same github org, we can see if we want to have these link out to assignment repos for easier updating, etc. Not a pressing concern right now.